### PR TITLE
Add reduce_sum shape grids (dim=-1)

### DIFF
--- a/bench/suites.yaml
+++ b/bench/suites.yaml
@@ -15,146 +15,123 @@ suites:
         shape: [256, 2048]
         dtype: float16
         dim: -1
-  reduce_short:
+  reduce_sum_short:
     warmup: 10
     iterations: 50
     cases:
-      - op: reduce
-        shape: [128, 256]
-        dtype: float16
-        dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [128, 1024]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [128, 2048]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [128, 4096]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [128, 8192]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
-        shape: [512, 256]
-        dtype: float16
-        dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [512, 1024]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [512, 2048]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [512, 4096]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [512, 8192]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
-        shape: [2048, 256]
-        dtype: float16
-        dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [2048, 1024]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [2048, 2048]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [2048, 4096]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [2048, 8192]
         dtype: float16
         dim: -1
-        reduce_op: sum
-  reduce_long:
+      - op: reduce_sum
+        shape: [8192, 1024]
+        dtype: float16
+        dim: -1
+      - op: reduce_sum
+        shape: [8192, 2048]
+        dtype: float16
+        dim: -1
+      - op: reduce_sum
+        shape: [8192, 4096]
+        dtype: float16
+        dim: -1
+      - op: reduce_sum
+        shape: [8192, 8192]
+        dtype: float16
+        dim: -1
+  reduce_sum_long:
     warmup: 10
     iterations: 50
     cases:
-      - op: reduce
+      - op: reduce_sum
         shape: [64, 16384]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [64, 32768]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [64, 65536]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [64, 131072]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [128, 16384]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [128, 32768]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [128, 65536]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [128, 131072]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [256, 16384]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [256, 32768]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [256, 65536]
         dtype: float16
         dim: -1
-        reduce_op: sum
-      - op: reduce
+      - op: reduce_sum
         shape: [256, 131072]
         dtype: float16
         dim: -1
-        reduce_op: sum

--- a/forge_cute_py/ops/reduce_sum.py
+++ b/forge_cute_py/ops/reduce_sum.py
@@ -19,6 +19,8 @@ def _reduce_sum(x: torch.Tensor, out: torch.Tensor, dim: int = -1) -> None:
 
     # Normalize dim to positive index
     dim = dim if dim >= 0 else x.ndim + dim
+    if dim != 1:
+        raise ValueError(f"reduce_sum supports dim in {{-1, 1}} (row-wise), got {dim}")
 
     # For now, use reference implementation
     # Future: call kernel implementation based on variant when available
@@ -36,7 +38,7 @@ def reduce_sum(x: torch.Tensor, dim: int = -1) -> torch.Tensor:
 
     Args:
         x: Input tensor of shape (M, N)
-        dim: Dimension to reduce over (-1 for last dim, 0 or 1)
+        dim: Dimension to reduce over (-1 for last dim, or 1)
 
     Returns:
         Reduced tensor of shape (M,) if dim=1 or (N,) if dim=0
@@ -50,13 +52,10 @@ def reduce_sum(x: torch.Tensor, dim: int = -1) -> torch.Tensor:
     # Normalize dim to positive index
     dim = dim if dim >= 0 else x.ndim + dim
 
-    # Determine output shape
-    if dim == 0:
-        out_shape = (x.shape[1],)
-    elif dim == 1:
-        out_shape = (x.shape[0],)
-    else:
-        raise ValueError(f"Invalid dim={dim} for 2D tensor")
+    if dim != 1:
+        raise ValueError(f"Invalid dim={dim} for row-wise reduce_sum")
+
+    out_shape = (x.shape[0],)
 
     out = torch.empty(out_shape, dtype=x.dtype, device=x.device)
     _reduce_sum(x, out, dim)

--- a/forge_cute_py/ref/reduce_sum.py
+++ b/forge_cute_py/ref/reduce_sum.py
@@ -4,7 +4,8 @@ import torch
 def reduce_sum(x: torch.Tensor, dim: int = -1) -> torch.Tensor:
     if x.ndim != 2:
         raise ValueError("reduce_sum expects a 2D tensor")
-    if dim not in (-1, 0, 1):
-        raise ValueError("reduce_sum expects dim in {-1, 0, 1} for 2D tensors")
+    if dim not in (-1, 1):
+        raise ValueError("reduce_sum expects dim in {-1, 1} for 2D tensors")
+    dim = dim if dim >= 0 else x.ndim + dim
     x_dtype = x.dtype
     return x.float().sum(dim=dim).to(x_dtype)


### PR DESCRIPTION
Summary:\n- enforce row-wise reduce_sum (dim=-1/1)\n- add correctness grid for reduce_sum\n- add short/long reduce_sum benchmark suites\n\nTests:\n- uv run pytest -q tests/test_reduce_sum.py\n\nDepends on #35\nRefs #29