### PR TITLE
Add softmax impl mode switch and benchmark/test wiring

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -128,9 +128,16 @@ non-zero tolerance in tests.
 uv run python bench/run.py --suite smoke
 uv run python bench/benchmark_copy_transpose.py --tile-size 16
 uv run python bench/benchmark_reduce.py
+uv run python bench/benchmark_online_softmax.py --impl auto
+uv run python bench/benchmark_online_softmax.py --impl kernel
 modal run bench/modal_bench.py --suite smoke --out results.json
 modal run bench/modal_bench.py --suite smoke --op reduce_sum --out results.json
 ```
+
+`softmax_online` backend mode is controlled by `FORGE_SOFTMAX_IMPL`:
+- `auto` (default): try kernel if present, otherwise fallback to reference.
+- `ref`: force reference path.
+- `kernel`: require kernel path and fail fast if missing/incomplete.
 
 > **Warning:** Modal benchmarks incur GPU costs. Review `bench/modal_bench.py`
 > and verify timeout/GPU settings before running. Start with `--suite smoke`

--- a/forge_cute_py/ops/softmax_online.py
+++ b/forge_cute_py/ops/softmax_online.py
@@ -1,31 +1,207 @@
+from __future__ import annotations
+
+import importlib
+import os
+from types import ModuleType
+from typing import Callable
+
 import torch
+
+SoftmaxForwardImpl = Callable[[torch.Tensor, int], torch.Tensor]
+SoftmaxBackwardImpl = Callable[[torch.Tensor, torch.Tensor, int], torch.Tensor]
+
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32, torch.float64)
+_SUPPORTED_IMPL_MODES = {"auto", "ref", "kernel"}
+
+
+def _normalize_dim(dim: int, ndim: int) -> int:
+    dim = dim if dim >= 0 else ndim + dim
+    if dim not in (0, 1):
+        raise ValueError(f"softmax_online expects dim in {{-1, 0, 1}} for 2D tensors, got {dim}")
+    return dim
+
+
+def _validate_impl_mode() -> str:
+    impl = os.getenv("FORGE_SOFTMAX_IMPL", "auto").strip().lower()
+    if impl not in _SUPPORTED_IMPL_MODES:
+        choices = ", ".join(sorted(_SUPPORTED_IMPL_MODES))
+        raise ValueError(f"FORGE_SOFTMAX_IMPL must be one of {{{choices}}}, got '{impl}'")
+    return impl
+
+
+def _load_kernel_module() -> tuple[ModuleType | None, str | None]:
+    module_name = "forge_cute_py.kernels.softmax_online"
+    try:
+        return importlib.import_module(module_name), None
+    except ModuleNotFoundError as exc:
+        if exc.name == module_name:
+            return None, f"module '{module_name}' was not found"
+        if exc.name is None:
+            return None, f"failed importing '{module_name}': {exc}"
+        return None, f"dependency '{exc.name}' missing while importing '{module_name}'"
+    except Exception as exc:  # pragma: no cover - defensive runtime diagnostics
+        return None, f"failed importing '{module_name}': {exc}"
+
+
+def _resolve_kernel_forward(module: ModuleType) -> SoftmaxForwardImpl:
+    for attr in ("softmax_fwd", "softmax_online"):
+        fn = getattr(module, attr, None)
+        if callable(fn):
+            return fn
+    raise AttributeError(
+        "kernel module must define a callable 'softmax_fwd(x, dim)' or 'softmax_online(x, dim)'"
+    )
+
+
+def _resolve_kernel_backward(module: ModuleType) -> SoftmaxBackwardImpl | None:
+    fn = getattr(module, "softmax_bwd", None)
+    if callable(fn):
+        return fn
+    return None
+
+
+def _call_forward(fn: SoftmaxForwardImpl, x: torch.Tensor, dim: int) -> torch.Tensor:
+    try:
+        return fn(x, dim=dim)
+    except TypeError:
+        return fn(x, dim)
+
+
+def _call_backward(
+    fn: SoftmaxBackwardImpl,
+    dy: torch.Tensor,
+    y: torch.Tensor,
+    dim: int,
+) -> torch.Tensor:
+    try:
+        return fn(dy, y, dim=dim)
+    except TypeError:
+        return fn(dy, y, dim)
+
+
+def _reference_softmax_forward(x: torch.Tensor, dim: int) -> torch.Tensor:
+    from forge_cute_py.ref import softmax_online as softmax_online_ref
+
+    return softmax_online_ref(x, dim=dim)
+
+
+def _reference_softmax_backward(dy: torch.Tensor, y: torch.Tensor, dim: int) -> torch.Tensor:
+    dot_product = (dy * y).sum(dim=dim, keepdim=True)
+    return y * (dy - dot_product)
+
+
+def _forward_impl(x: torch.Tensor, dim: int) -> torch.Tensor:
+    impl = _validate_impl_mode()
+    if impl == "ref":
+        return _reference_softmax_forward(x, dim)
+
+    module, reason = _load_kernel_module()
+    if module is None:
+        if impl == "auto":
+            return _reference_softmax_forward(x, dim)
+        raise NotImplementedError(
+            "FORGE_SOFTMAX_IMPL=kernel requested, but softmax kernel is unavailable: "
+            f"{reason}. Add forge_cute_py/kernels/softmax_online.py with softmax_fwd()."
+        )
+
+    try:
+        kernel_forward = _resolve_kernel_forward(module)
+    except AttributeError as exc:
+        if impl == "auto":
+            return _reference_softmax_forward(x, dim)
+        raise NotImplementedError(
+            "FORGE_SOFTMAX_IMPL=kernel requested, but softmax kernel forward entry point is "
+            f"incomplete: {exc}"
+        ) from exc
+
+    try:
+        return _call_forward(kernel_forward, x, dim)
+    except NotImplementedError as exc:
+        if impl == "auto":
+            return _reference_softmax_forward(x, dim)
+        raise NotImplementedError(
+            "FORGE_SOFTMAX_IMPL=kernel requested, but softmax kernel forward is not implemented."
+        ) from exc
+
+
+def _backward_impl(dy: torch.Tensor, y: torch.Tensor, dim: int) -> torch.Tensor:
+    impl = _validate_impl_mode()
+    if impl == "ref":
+        return _reference_softmax_backward(dy, y, dim)
+
+    module, reason = _load_kernel_module()
+    if module is None:
+        if impl == "auto":
+            return _reference_softmax_backward(dy, y, dim)
+        raise NotImplementedError(
+            "FORGE_SOFTMAX_IMPL=kernel requested, but softmax kernel is unavailable: "
+            f"{reason}. Add forge_cute_py/kernels/softmax_online.py with softmax_bwd()."
+        )
+
+    kernel_backward = _resolve_kernel_backward(module)
+    if kernel_backward is None:
+        if impl == "auto":
+            return _reference_softmax_backward(dy, y, dim)
+        raise NotImplementedError(
+            "FORGE_SOFTMAX_IMPL=kernel requested, but 'softmax_bwd' is missing in "
+            "forge_cute_py.kernels.softmax_online."
+        )
+
+    try:
+        return _call_backward(kernel_backward, dy, y, dim)
+    except NotImplementedError as exc:
+        if impl == "auto":
+            return _reference_softmax_backward(dy, y, dim)
+        raise NotImplementedError(
+            "FORGE_SOFTMAX_IMPL=kernel requested, but softmax kernel backward is not implemented."
+        ) from exc
+
+
+def _ensure_forward_inputs(x: torch.Tensor, out: torch.Tensor, dim: int) -> int:
+    if x.dim() != 2:
+        raise ValueError("Input must be 2D")
+    if not x.is_cuda:
+        raise ValueError("Tensor must be on CUDA device")
+    if x.dtype not in _SUPPORTED_DTYPES:
+        raise ValueError(f"Unsupported dtype: {x.dtype}")
+    if out.shape != x.shape:
+        raise ValueError("Output shape must match input")
+    if out.dtype != x.dtype:
+        raise ValueError("Output dtype must match input dtype")
+    if out.device != x.device:
+        raise ValueError("Output device must match input device")
+    return _normalize_dim(dim, x.ndim)
+
+
+def _ensure_backward_inputs(dy: torch.Tensor, y: torch.Tensor, dx: torch.Tensor, dim: int) -> int:
+    if dy.dim() != 2 or y.dim() != 2 or dx.dim() != 2:
+        raise ValueError("Tensors must be 2D")
+    if dy.shape != y.shape or y.shape != dx.shape:
+        raise ValueError("All tensors must have same shape")
+    if not dy.is_cuda or not y.is_cuda or not dx.is_cuda:
+        raise ValueError("Tensors must be on CUDA")
+    if dy.dtype != y.dtype or y.dtype != dx.dtype:
+        raise ValueError("dy, y, and dx must have same dtype")
+    if dy.dtype not in _SUPPORTED_DTYPES:
+        raise ValueError(f"Unsupported dtype: {dy.dtype}")
+    return _normalize_dim(dim, dy.ndim)
 
 
 @torch.library.custom_op("forge_cute_py::_softmax_fwd", mutates_args={"out"})
 def _softmax_fwd(x: torch.Tensor, out: torch.Tensor, dim: int = -1) -> None:
-    """Softmax forward pass.
-
-    Args:
-        x: Input tensor of shape (M, N)
-        out: Output tensor of same shape as x (mutated in-place)
-        dim: Dimension to apply softmax over
-    """
-    assert x.dim() == 2, "Input must be 2D"
-    assert x.is_cuda, "Tensor must be on CUDA device"
-    assert x.dtype in [torch.float16, torch.bfloat16, torch.float32, torch.float64], (
-        "Unsupported dtype"
-    )
-    assert out.shape == x.shape, "Output shape must match input"
-
-    # Normalize dim to positive index
-    dim = dim if dim >= 0 else x.ndim + dim
-    assert dim in [0, 1], f"dim must be 0 or 1 for 2D tensors, got {dim}"
-
-    # For now, use reference implementation
-    # Future: call kernel implementation when available
-    from forge_cute_py.ref import softmax_online as softmax_online_ref
-
-    result = softmax_online_ref(x, dim=dim)
+    """Softmax forward pass."""
+    dim = _ensure_forward_inputs(x, out, dim)
+    result = _forward_impl(x, dim)
+    if result.shape != x.shape:
+        raise ValueError(
+            f"softmax forward produced invalid shape {result.shape}, expected {x.shape}"
+        )
+    if result.dtype != x.dtype:
+        raise ValueError(
+            f"softmax forward produced invalid dtype {result.dtype}, expected {x.dtype}"
+        )
+    if result.device != x.device:
+        raise ValueError(f"softmax forward produced output on {result.device}, expected {x.device}")
     out.copy_(result)
 
 
@@ -41,32 +217,21 @@ def softmax_fwd(x: torch.Tensor, dim: int = -1) -> torch.Tensor:
 
 @torch.library.custom_op("forge_cute_py::_softmax_backward", mutates_args={"dx"})
 def _softmax_backward(dy: torch.Tensor, y: torch.Tensor, dx: torch.Tensor, dim: int = -1) -> None:
-    """Softmax backward pass.
-
-    For softmax output y = softmax(x), gradient: grad_x = y * (grad_y - dot)
-    where dot = (grad_y * y).sum(dim, keepdim=True)
-
-    Args:
-        dy: Upstream gradients (M, N)
-        y: Softmax output (M, N)
-        dx: Input gradients (mutated in-place)
-        dim: Dimension softmax was applied over
-    """
-    assert dy.dim() == 2 and y.dim() == 2, "Tensors must be 2D"
-    assert dy.shape == y.shape == dx.shape, "All tensors must have same shape"
-    assert dy.is_cuda and y.is_cuda, "Tensors must be on CUDA"
-    assert dy.dtype == y.dtype, "dy and y must have same dtype"
-    assert dy.dtype in [torch.float16, torch.bfloat16, torch.float32, torch.float64], (
-        "Unsupported dtype"
-    )
-
-    # Normalize dim
-    dim = dim if dim >= 0 else dy.ndim + dim
-    assert dim in [0, 1], f"dim must be 0 or 1 for 2D, got {dim}"
-
-    # Compute gradient (numerically stable)
-    dot_product = (dy * y).sum(dim=dim, keepdim=True)
-    result = y * (dy - dot_product)
+    """Softmax backward pass."""
+    dim = _ensure_backward_inputs(dy, y, dx, dim)
+    result = _backward_impl(dy, y, dim)
+    if result.shape != dy.shape:
+        raise ValueError(
+            f"softmax backward produced invalid shape {result.shape}, expected {dy.shape}"
+        )
+    if result.dtype != dy.dtype:
+        raise ValueError(
+            f"softmax backward produced invalid dtype {result.dtype}, expected {dy.dtype}"
+        )
+    if result.device != dy.device:
+        raise ValueError(
+            f"softmax backward produced output on {result.device}, expected {dy.device}"
+        )
     dx.copy_(result)
 
 
@@ -96,19 +261,11 @@ class SoftmaxOnlineFunction(torch.autograd.Function):
 
 
 def softmax_online(x: torch.Tensor, dim: int = -1) -> torch.Tensor:
-    """Online softmax with automatic differentiation support.
+    """Online softmax with autograd support.
 
-    Args:
-        x: Input tensor of shape (M, N)
-        dim: Dimension to apply softmax (-1, 0, or 1)
-
-    Returns:
-        Softmax output tensor of same shape and dtype as input
-
-    Examples:
-        >>> x = torch.randn(32, 128, device='cuda', requires_grad=True)
-        >>> y = softmax_online(x, dim=-1)
-        >>> loss = y.sum()
-        >>> loss.backward()  # Gradients computed automatically
+    Backend selection is controlled by FORGE_SOFTMAX_IMPL:
+    - auto (default): try kernel first, fallback to reference
+    - ref: force reference implementation
+    - kernel: require kernel implementation (raise if unavailable)
     """
     return SoftmaxOnlineFunction.apply(x, dim)


### PR DESCRIPTION
## Summary
- add `FORGE_SOFTMAX_IMPL` mode selection to `softmax_online` (`auto`, `ref`, `kernel`)
- in `kernel` mode, fail fast with clear errors when kernel module/entrypoints are missing
- keep `auto` mode contributor-friendly by falling back to the reference implementation
- add tests for impl-mode behavior and invalid mode handling
- add `--impl` to `bench/benchmark_online_softmax.py` and remove the hard N divisibility assertion
- make `bench/run.py` skip softmax cases cleanly when strict kernel mode is unavailable
- document softmax impl mode usage in `DEVELOPMENT.md`

## Validation
- `uv run ruff check forge_cute_py/ops/softmax_online.py tests/test_softmax_online.py bench/benchmark_online_softmax.py bench/run.py`
- `uv run ruff format forge_cute_py/ops/softmax_online.py tests/test_softmax_online.py bench/benchmark_online_softmax.py bench/run.py`
- `uv run pytest tests/test_softmax_online.py -q`
- `uv run pytest -q`
- `uv run python bench/benchmark_online_softmax.py --m-sizes 64 --n-sizes 256 --dtypes float16 --warmup 2 --iterations 5 --impl auto`
- `uv run python bench/benchmark_online_softmax.py --m-sizes 64 --n-sizes 256 --dtypes float16 --warmup 2 --iterations 5 --impl kernel`
- `FORGE_SOFTMAX_IMPL=kernel uv run python bench/run.py --suite smoke --op softmax_online`

## Notes
- includes cherry-picked benchmark script commit authored by `jonah <jsamost@gmail.com>` (`a9d4983`)
- follow-up docs-only patch will be opened separately
