### PR TITLE
Docs: align softmax modes and release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reference implementations for all Week 0-2 operations
 - Comprehensive test suite with PyTorch reference validation
 - Environment check utility (`forge_cute_py.env_check`)
-- Documentation: README, DEVELOPMENT.md (#11), CLAUDE.md, CONTRIBUTING.md with contribution policy (#7)
+- Documentation: README, DEVELOPMENT.md (#11), CONTRIBUTING.md with contribution policy (#7)
 - Pre-commit hooks installation instructions in CONTRIBUTING.md (#7)
 - Support for float16, bfloat16, and float32 dtypes
+- `FORGE_SOFTMAX_IMPL` softmax mode selection (`auto`, `ref`, `kernel`)
 
 ### Changed
 - Modal benchmarks now use strict GPU matching (`!` suffix) for consistent hardware
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced error messages with device information for better debugging
 - Set tolerance to 0 (exact comparison) for transpose correctness tests
 - Updated documentation to reflect current three-layer architecture and modern PyTorch patterns
+- Added `--impl` to `bench/benchmark_online_softmax.py` and updated benchmark handling for strict kernel mode
 
 ### Infrastructure
 - Package scaffolding with `pyproject.toml` and proper Python 3.13+ support

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,8 @@ A change that affects kernels or harness behavior should include:
 
 The project is currently in `v0.1.0` development:
 - Focused on harness stabilization and Week 0-2 kernel implementations
-- Not yet tagged - will be tagged when v0.1.0 milestones are complete
+- Release candidate tag exists: `v0.1.0-rc1`
+- Final `v0.1.0` tag is pending completion of remaining milestones
 - See [ROADMAP.md](ROADMAP.md) for detailed progress tracking
 
 ### Release process (for maintainers)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -31,7 +31,7 @@ pattern:
 2. **Public API** (`op_name`): Allocates output tensor, calls internal op, returns
    result. For ops with autograd, wraps a `torch.autograd.Function`.
 
-This enables usage via both `forge_cute_py.op_name()` and
+This enables usage via both `forge_cute_py.ops.op_name()` and
 `torch.ops.forge_cute_py._op_name()`.
 
 ### Current implementation status (v0.1)
@@ -41,7 +41,7 @@ This enables usage via both `forge_cute_py.op_name()` and
 | `copy_transpose` | CuTe DSL | Fully implemented with tile-based shared memory |
 | `reduce` | CuTe DSL | Placeholder (sum only) |
 | `reduce_sum` | Reference | Placeholder (awaiting benchmarking) |
-| `softmax_online` | Reference | Stub with autograd support (kernel TODO) |
+| `softmax_online` | Reference | Stub with autograd support (kernel TODO, mode-gated via `FORGE_SOFTMAX_IMPL`) |
 
 ### Development flow
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 `forge-cute-py` is a project for developing and evaluating **CuTe DSL** kernels in Python.
 
-As initially planned, it should provides a workflow to **run kernels, validate correctness against PyTorch references, benchmark performance, and profile**.
+As initially planned, it provides a workflow to **run kernels, validate correctness against PyTorch references, benchmark performance, and profile**.
 
 ## Current scope (v0.1)
 
@@ -30,7 +30,7 @@ Not currently in scope for v0: FlashAttention kernels (FA1+), decode/KV-cache, F
 
 ```bash
 uv sync
-````
+```
 
 If you need an editable/dev install, use your normal `uv` workflow (project is expected to be runnable via `uv run ...`).
 
@@ -84,6 +84,8 @@ Run a standalone benchmark:
 
 ```bash
 uv run python bench/benchmark_copy_transpose.py --tile-size 16
+uv run python bench/benchmark_online_softmax.py --impl auto
+uv run python bench/benchmark_online_softmax.py --impl kernel
 ```
 
 Profile a kernel with helper script:
@@ -108,7 +110,7 @@ ncu --set full -o profiles/copy_transpose uv run python bench/benchmark_copy_tra
 | copy_transpose | Implemented | tile_size=16/32 | CuTe DSL kernel with tiled shared memory |
 | reduce | Implemented (sum only) | - | Placeholder (awaiting benchmarking) |
 | reduce_sum | Stub (ref) | - | Placeholder (awaiting benchmarking) |
-| softmax_online | Stub (ref) | single-pass | Uses PyTorch reference with autograd support; kernel to be implemented |
+| softmax_online | Stub (ref) | single-pass | Reference-backed by default; `FORGE_SOFTMAX_IMPL` can force `ref` or strict `kernel` mode |
 
 ---
 
@@ -150,9 +152,16 @@ uv run pre-commit run --all-files                     # Run linting/formatting
 uv run python bench/run.py --suite smoke              # Run benchmark suite
 uv run python bench/run.py --suite smoke --out out.json  # Save results
 uv run python bench/benchmark_copy_transpose.py       # Standalone benchmark
-uv run python bench/benchmark_reduce.py              # Standalone benchmark
+uv run python bench/benchmark_reduce.py               # Standalone benchmark
+uv run python bench/benchmark_online_softmax.py --impl auto    # softmax fwd+bwd (fallback allowed)
+uv run python bench/benchmark_online_softmax.py --impl kernel  # softmax fwd+bwd (hard fail if kernel missing)
 modal run bench/modal_bench.py --suite smoke --out results.json  # Remote run on B200 via Modal
 ```
+
+`softmax_online` mode is controlled by `FORGE_SOFTMAX_IMPL`:
+- `auto` (default): try kernel first, then fallback to reference.
+- `ref`: force reference implementation.
+- `kernel`: require kernel implementation and fail fast if unavailable.
 
 ### Modal setup (remote benchmarks)
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ Target: Harness infrastructure + Week 0-2 kernel implementations aligned to Kern
 - [x] Profiling documentation and helper scripts
 - [x] CI/CD with ruff linting and formatting
 - [x] Pre-commit hooks configuration
-- [x] Documentation (README, CONTRIBUTING, CLAUDE.md)
+- [x] Documentation (README, CONTRIBUTING, DEVELOPMENT)
 
 ### Copy/Transpose Kernel
 - [x] CuTe DSL kernel implementation (`forge_cute_py/kernels/copy_transpose.py`)


### PR DESCRIPTION
## Summary
- fix stale docs references to removed `CLAUDE.md`
- correct public API wording in `DEVELOPMENT.md` (`forge_cute_py.ops.<op>()`)
- update README benchmark quick reference with softmax benchmark commands and impl-mode notes
- clarify current release state in `CONTRIBUTING.md` (`v0.1.0-rc1` exists; final `v0.1.0` pending)
- add changelog bullets for softmax impl-mode selection and benchmark CLI updates

## Scope
- docs-only patch (`README.md`, `DEVELOPMENT.md`, `ROADMAP.md`, `CHANGELOG.md`, `CONTRIBUTING.md`)
- no runtime code changes

## Notes
- follow-up to #39
