### PR TITLE
misc: fix pre-commit config and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 .venv/
 *.egg-info/
+.vscode/
 
 .pytest_cache/
 .ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,12 @@ repos:
     rev: 0.9.21
     hooks:
       - id: uv-lock
-
-repos:
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.14.10
-  hooks:
-    # Run the linter.
-    - id: ruff-check
-      args: [ --fix ]
-    # Run the formatter.
-    - id: ruff-format
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.14.10
+    hooks:
+      # Run the linter.
+      - id: ruff-check
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format


### PR DESCRIPTION
Fix #46

After this fix, we can install three hooks correctly, and vscode config directory is added to gitignore.

```
❯ uv run pre-commit uninstall
pre-commit uninstalled
❯ uv run pre-commit install
pre-commit installed at .git/hooks/pre-commit
❯ uv run pre-commit run -a
[INFO] Installing environment for https://github.com/astral-sh/uv-pre-commit.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
uv-lock..................................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
```